### PR TITLE
Happy Case: Get Datasource chainer

### DIFF
--- a/src/DataSourceChainer.js
+++ b/src/DataSourceChainer.js
@@ -1,7 +1,6 @@
+var getRequestCycle = require('./getRequestCycle');
 var Subscribable = require('./Subscribable');
-var AssignableDisposable = require('./AssignableDisposable');
 var EMPTY_SOURCES_ARRAY = [];
-var EMPTY_DISPOSABLE = {dispose: function empty() {}};
 
 /**
  * DataSourceChainer takes in a list of dataSources and calls them one at a time
@@ -31,35 +30,13 @@ DataSourceChainer.prototype = {
             };
 
             // Performs the internal get request loop.
-            return self._getRequestCycle(self, self._sources, 0,
-                                         paths, seed, observer);
+            return getRequestCycle(self._sources, 0,
+                                   paths, seed, observer);
         });
     },
     set: function set(jsonGraph) {
     },
     call: function call(callPath, args, suffixes, paths) {
-    },
-
-    /**
-     * Performs the requesting of the data from each dataSource until exhausted
-     * or completed.
-     * @private
-     */
-    _getRequestCycle: function _getRequestCycle(sourceChainer, sources,
-                                                sourceIndex, remainingPaths,
-                                                seed, observer, disposable) {
-        var currentSource = sources[sourceIndex];
-        disposable = disposable || new AssignableDisposable();
-
-        // Sources have been exhausted, time to finish
-        if (!currentSource) {
-            seed.unhandledPaths = remainingPaths;
-            observer.onNext(seed);
-            observer.onCompleted();
-            return EMPTY_DISPOSABLE;
-        }
-
-        return disposable;
     }
 };
 

--- a/src/getRequestCycle.js
+++ b/src/getRequestCycle.js
@@ -45,6 +45,7 @@ module.exports = function getRequestCycle(sources, sourceIndex, remainingPaths,
             // TODO: If there has been an error what do we do?
             // Are all paths considered 'unhandledPaths?'  Its not really
             // the case.
+            observer.onError(dataSourceError);
         }, function onCompleted() {
             // Exit condition.
             if (disposable.disposed) {

--- a/src/getRequestCycle.js
+++ b/src/getRequestCycle.js
@@ -1,0 +1,81 @@
+var AssignableDisposable = require('./AssignableDisposable');
+var EMPTY_DISPOSABLE = {dispose: function empty() {}};
+
+/**
+ * Performs the requesting of the data from each dataSource until exhausted
+ * or completed.
+ * @private
+ */
+// TODO: Clean up this function as its very large.
+module.exports = function getRequestCycle(sources, sourceIndex, remainingPaths,
+                                          seed, observer, disposable) {
+
+    var currentSource = sources[sourceIndex];
+    disposable = disposable || new AssignableDisposable();
+
+    // Sources have been exhausted, time to finish
+    if (!currentSource || !remainingPaths || remainingPaths.length === 0) {
+        seed.unhandledPaths = remainingPaths;
+        observer.onNext(seed);
+        observer.onCompleted();
+        return EMPTY_DISPOSABLE;
+    }
+
+    // we have a current source so we need to attempt to fulfill the
+    // remaining paths.
+
+    // If the source index is greater than 1 then we need to attemp to
+    // optimize / reduce missing paths with our already formulated seed.
+    if (sourceIndex > 1) {
+        // TODO: optimize / reduce
+    }
+
+    // Request from the current source.
+    var jsonGraphFromSource;
+    disposable.currentDisposable = currentSource.
+        get(remainingPaths).
+        subscribe(function onNext(jsonGraphEnvelop) {
+            jsonGraphFromSource = jsonGraphEnvelop;
+        }, function onError(dataSourceError) {
+            // Exit condition.
+            if (disposable.disposed) {
+                return;
+            }
+
+            // TODO: If there has been an error what do we do?
+            // Are all paths considered 'unhandledPaths?'  Its not really
+            // the case.
+        }, function onCompleted() {
+            // Exit condition.
+            if (disposable.disposed) {
+                return;
+            }
+
+            // We need to merge the results into our seed, if the source
+            // is the second or later source.
+            if (sourceIndex === 0) {
+                seed = {
+                    jsonGraph: jsonGraphFromSource.jsonGraph,
+                    paths: jsonGraphFromSource.paths
+                };
+            }
+
+            else {
+                // TODO: Merge algorithm
+            }
+
+            // are there unhandledPaths?
+            if (jsonGraphFromSource.unhandledPaths &&
+                jsonGraphFromSource.unhandledPaths.length) {
+            }
+
+            // We have finished here.
+            else {
+                observer.onNext(seed);
+                observer.onCompleted();
+            }
+        });
+
+
+    return disposable;
+};

--- a/test/AutoRespondDataSource.js
+++ b/test/AutoRespondDataSource.js
@@ -15,7 +15,12 @@ AutoRespondDataSource.prototype.get = function get() {
         }
 
         function respond() {
-            onNext(self._data);
+            if (options.error) {
+                onError(e);
+            }
+            else {
+                onNext(self._data);
+            }
         }
 
         function onNext(data) {

--- a/test/AutoRespondDataSource.js
+++ b/test/AutoRespondDataSource.js
@@ -15,21 +15,12 @@ AutoRespondDataSource.prototype.get = function get() {
         }
 
         function respond() {
-            if (options.error) {
-                onError(e);
-            }
-            else {
-                onNext(self._data);
-            }
+            onNext(self._data);
         }
 
         function onNext(data) {
             observer.onNext(data);
             observer.onCompleted();
-        }
-
-        function onError(e) {
-            observer.onError(e);
         }
     });
 };

--- a/test/AutoRespondDataSource.js
+++ b/test/AutoRespondDataSource.js
@@ -1,0 +1,32 @@
+var Subscribable = require('./../src/Subscribable');
+var AutoRespondDataSource = function AutoRespondDataSource(data, options) {
+    this._options = options || {};
+    this._data = data;
+};
+
+AutoRespondDataSource.prototype.get = function get() {
+    var self = this;
+    var options = self._options;
+    return new Subscribable(function getSubscribe(observer) {
+        if (options.wait) {
+            setTimeout(respond, options.wait);
+        } else {
+            respond();
+        }
+
+        function respond() {
+            onNext(self._data);
+        }
+
+        function onNext(data) {
+            observer.onNext(data);
+            observer.onCompleted();
+        }
+
+        function onError(e) {
+            observer.onError(e);
+        }
+    });
+};
+
+module.exports = AutoRespondDataSource;

--- a/test/src/DataSourceChainer.spec.js
+++ b/test/src/DataSourceChainer.spec.js
@@ -3,6 +3,7 @@ var sinon = require('sinon');
 var toObservable = require('./../toObservable');
 var noOp = function noOp() {};
 var expect = require('chai').expect;
+var AutoRespondDataSource = require('./../AutoRespondDataSource');
 
 describe('DataSourceChainer', function() {
     it('should be able to construct an empty chainer and make get requests.', function(done) {
@@ -22,5 +23,59 @@ describe('DataSourceChainer', function() {
             }).
             subscribe(noOp, done, done);
 
+    });
+
+    it('should be ok with happy case DataSource where the first DataSource fills all data (sync).', function(done) {
+        var innerSource = new AutoRespondDataSource({
+            jsonGraph: {
+                hello: {
+                    world: 'foo bar'
+                }
+            },
+            paths: [['hello', 'world']]
+        });
+        var source = new DataSourceChainer([innerSource]);
+        var onNext = sinon.spy();
+        toObservable(source.
+            get([['hello', 'world']])).
+            doAction(onNext, noOp, function() {
+                expect(onNext.calledOnce).to.be.ok;
+                expect(onNext.getCall(0).args[0]).to.deep.equals({
+                    jsonGraph: {
+                        hello: {
+                            world: 'foo bar'
+                        }
+                    },
+                    paths: [['hello', 'world']]
+                });
+            }).
+            subscribe(noOp, done, done);
+    });
+
+    it('should be ok with happy case DataSource where the first DataSource fills all data (async).', function(done) {
+        var innerSource = new AutoRespondDataSource({
+            jsonGraph: {
+                hello: {
+                    world: 'foo bar'
+                }
+            },
+            paths: [['hello', 'world']]
+        }, {wait: 100});
+        var source = new DataSourceChainer([innerSource]);
+        var onNext = sinon.spy();
+        toObservable(source.
+            get([['hello', 'world']])).
+            doAction(onNext, noOp, function() {
+                expect(onNext.calledOnce).to.be.ok;
+                expect(onNext.getCall(0).args[0]).to.deep.equals({
+                    jsonGraph: {
+                        hello: {
+                            world: 'foo bar'
+                        }
+                    },
+                    paths: [['hello', 'world']]
+                });
+            }).
+            subscribe(noOp, done, done);
     });
 });


### PR DESCRIPTION
This is the happy case for a get request to the inner datasources where the first one responds without any `unhandledPaths`
#4 - partial
